### PR TITLE
Update 0.0.18: Prysm v1.3.3

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth2validator.avado.dnp.dappnode.eth",
-  "version": "0.0.17",
-  "upstream": "v1.3.2",
+  "version": "0.0.18",
+  "upstream": "v1.3.3",
   "title": "Prysm ETH2.0 validator",
   "description": "the ETH2.0 validator for AVADO",
   "avatar": "/ipfs/Qmf7yFka8z2QLRrDyT1ESNRwP9a1tdufEEtBghXHFUEQEP",
@@ -14,9 +14,9 @@
     "environment": [
       "EXTRA_OPTS=--graffiti=AVADO --beacon-rpc-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:4000 --beacon-rpc-gateway-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:3500"
     ],
-    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.17.tar.xz",
-    "hash": "/ipfs/QmQ9aryQXphGBUkV9pUxpquRn4YddjcRGoke78D6xRQ8TG",
-    "size": 43730632,
+    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.18.tar.xz",
+    "hash": "/ipfs/QmbX8fow3ahd9hEz5nX6B1uzMm4vWvruArneLRBwpD8C9Y",
+    "size": 46279124,
     "restart": "always"
   },
   "author": "AVADO",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   eth2validator.avado.dnp.dappnode.eth:
-    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.17'
+    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.18'
     build:
       context: ./build
       args:
-        VERSION: v1.3.2
+        VERSION: v1.3.3
     environment:
       - >-
         EXTRA_OPTS=--graffiti="AVADO"

--- a/releases.json
+++ b/releases.json
@@ -111,10 +111,17 @@
     }
   },
   "0.0.17": {
-    "hash": "/ipfs/Qmcuz4FawmjFShp9NqTTSfmU8paH5Rib8swBxGTdmwomqx",
+    "hash": "/ipfs/QmUFtmBYfXQCiC4nMfEmgUfvvQG9PYhBvRzmxECT1V6GeN",
     "type": "manifest",
     "uploadedTo": {
-      "http://80.208.229.228:5001": "Sun, 07 Mar 2021 22:21:41 GMT"
+      "http://80.208.229.228:5001": "Tue, 09 Mar 2021 07:32:20 GMT"
+    }
+  },
+  "0.0.18": {
+    "hash": "/ipfs/QmfQ7HY63VzYnzYeEoMRGrwJ3GMSNjcrGr4CeymRAuzsz5",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Tue, 09 Mar 2021 07:50:37 GMT"
     }
   }
 }


### PR DESCRIPTION
@sponnet Note that you need to release the beacon chain first, next its hash needs to  be added to the dependencies field in `dappnode_package.json`