### PR TITLE
Update 0.0.21: Prysm v1.3.6

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth2validator.avado.dnp.dappnode.eth",
-  "version": "0.0.20",
-  "upstream": "v1.3.5",
+  "version": "0.0.21",
+  "upstream": "v1.3.6",
   "title": "Prysm ETH2.0 validator",
   "description": "the ETH2.0 validator for AVADO",
   "avatar": "/ipfs/Qmf7yFka8z2QLRrDyT1ESNRwP9a1tdufEEtBghXHFUEQEP",
@@ -14,9 +14,9 @@
     "environment": [
       "EXTRA_OPTS=--graffiti=AVADO --beacon-rpc-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:4000 --beacon-rpc-gateway-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:3500"
     ],
-    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.20.tar.xz",
-    "hash": "/ipfs/QmVn8qs7yA9TCWxZVYoTQcBHjoqNFFs6ATYgiAYS4rgocR",
-    "size": 46408928,
+    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.21.tar.xz",
+    "hash": "/ipfs/QmQQJvC8XtBGnaToxCqjJ6HN6hYtpugg5i278JVoLyMVEx",
+    "size": 46932492,
     "restart": "always"
   },
   "author": "AVADO",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   eth2validator.avado.dnp.dappnode.eth:
-    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.20'
+    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.21'
     build:
       context: ./build
       args:
-        VERSION: v1.3.5
+        VERSION: v1.3.6
     environment:
       - >-
         EXTRA_OPTS=--graffiti="AVADO"

--- a/releases.json
+++ b/releases.json
@@ -137,5 +137,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Tue, 30 Mar 2021 06:43:16 GMT"
     }
+  },
+  "0.0.21": {
+    "hash": "/ipfs/QmdA6sP5PFr7nAox7c5Ls53LYP14Acj16ifUcHudCMmmaQ",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 07 Apr 2021 05:52:44 GMT"
+    }
   }
 }


### PR DESCRIPTION
Hash /ipfs/QmdA6sP5PFr7nAox7c5Ls53LYP14Acj16ifUcHudCMmmaQ

Features: 
- Advancements in peer scoring

Security: 
- This release contains an update to the most recent blst cryptography library. Updating to this release is strongly recommended.