### PR TITLE
Update 0.0.25: Prysm v1.3.9

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 
 WORKDIR /app/validator 
 ENV DOWNLOAD_URL https://github.com/prysmaticlabs/prysm/releases/download
-ENV BINARY_URL ${DOWNLOAD_URL}/v1.3.8-hotfix%2B6c0942/validator-${VERSION}-linux-amd64
+ENV BINARY_URL ${DOWNLOAD_URL}/${VERSION}/validator-${VERSION}-linux-amd64
 
 RUN wget $BINARY_URL -O validator && \
     chmod +x  validator

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth2validator.avado.dnp.dappnode.eth",
-  "version": "0.0.24",
-  "upstream": "v1.3.8-hotfix.6c0942",
+  "version": "0.0.25",
+  "upstream": "v1.3.9",
   "title": "Prysm ETH2.0 validator",
   "description": "the ETH2.0 validator for AVADO",
   "avatar": "/ipfs/Qmf7yFka8z2QLRrDyT1ESNRwP9a1tdufEEtBghXHFUEQEP",
@@ -14,9 +14,9 @@
     "environment": [
       "EXTRA_OPTS=--graffiti=AVADO --beacon-rpc-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:4000 --beacon-rpc-gateway-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:3500"
     ],
-    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.24.tar.xz",
-    "hash": "/ipfs/QmSksQg9HZkvmVySxirrrAg4HkasH5JqHroxTWwUBPHPC3",
-    "size": 44599068,
+    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.25.tar.xz",
+    "hash": "/ipfs/QmR6jxCwZtTVoADn3sfeNWyUMnWXh9E7Y1YhFTmiBShtMY",
+    "size": 47225372,
     "restart": "always"
   },
   "author": "AVADO",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   eth2validator.avado.dnp.dappnode.eth:
-    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.24'
+    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.25'
     build:
       context: ./build
       args:
-        VERSION: v1.3.8-hotfix.6c0942
+        VERSION: v1.3.9
     environment:
       - >-
         EXTRA_OPTS=--graffiti="AVADO"

--- a/releases.json
+++ b/releases.json
@@ -165,5 +165,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Sun, 25 Apr 2021 06:47:58 GMT"
     }
+  },
+  "0.0.25": {
+    "hash": "/ipfs/QmZSQTwxj9TjcUNm4Ty6yKpNstWjR7rYJfN2RomySCeBDM",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 12 May 2021 19:51:23 GMT"
+    }
   }
 }


### PR DESCRIPTION
Update 0.0.25: Prysm v1.3.9

Manifest hash : /ipfs/QmZSQTwxj9TjcUNm4Ty6yKpNstWjR7rYJfN2RomySCeBDM

release notes:  https://github.com/prysmaticlabs/prysm/releases

```
This release has a number of important changes, including a fix for a mainnet issue that was issued as a "hotfix".

    Initialize Data Correctly For Powchain Service #8812
    Independent eth1 voting #8811

Updating to this release is recommended as there are a number of improvements since v1.3.8 and v1.3.8-hotfix+6c0942.
```