### PR TITLE
Update 0.0.26: Prysm v1.3.10

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth2validator.avado.dnp.dappnode.eth",
-  "version": "0.0.25",
-  "upstream": "v1.3.9",
+  "version": "0.0.26",
+  "upstream": "v1.3.10",
   "title": "Prysm ETH2.0 validator",
   "description": "the ETH2.0 validator for AVADO",
   "avatar": "/ipfs/Qmf7yFka8z2QLRrDyT1ESNRwP9a1tdufEEtBghXHFUEQEP",
@@ -14,9 +14,9 @@
     "environment": [
       "EXTRA_OPTS=--graffiti=AVADO --beacon-rpc-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:4000 --beacon-rpc-gateway-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:3500"
     ],
-    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.25.tar.xz",
-    "hash": "/ipfs/QmR6jxCwZtTVoADn3sfeNWyUMnWXh9E7Y1YhFTmiBShtMY",
-    "size": 47225372,
+    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.26.tar.xz",
+    "hash": "/ipfs/QmeNdUWK82g1ZCg6yh8BY6MBuYH7vKzxowmtwpYzHxHQvK",
+    "size": 45714964,
     "restart": "always"
   },
   "author": "AVADO",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   eth2validator.avado.dnp.dappnode.eth:
-    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.25'
+    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.26'
     build:
       context: ./build
       args:
-        VERSION: v1.3.9
+        VERSION: v1.3.10
     environment:
       - >-
         EXTRA_OPTS=--graffiti="AVADO"

--- a/releases.json
+++ b/releases.json
@@ -172,5 +172,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Wed, 12 May 2021 19:51:23 GMT"
     }
+  },
+  "0.0.26": {
+    "hash": "/ipfs/QmWSehZprscDwsNoUdYaeXcgzQyTyBX8mQkKA7PiaA8Qfb",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 02 Jun 2021 18:52:46 GMT"
+    }
   }
 }


### PR DESCRIPTION
This release contains a security fix and it is recommended that everyone update as soon as practical.

Manifest hash : /ipfs/QmWSehZprscDwsNoUdYaeXcgzQyTyBX8mQkKA7PiaA8Qfb
