### PR TITLE
Update 0.0.27: Prysm v1.3.11

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth2validator.avado.dnp.dappnode.eth",
-  "version": "0.0.26",
-  "upstream": "v1.3.10",
+  "version": "0.0.27",
+  "upstream": "v1.3.11",
   "title": "Prysm ETH2.0 validator",
   "description": "the ETH2.0 validator for AVADO",
   "avatar": "/ipfs/Qmf7yFka8z2QLRrDyT1ESNRwP9a1tdufEEtBghXHFUEQEP",
@@ -14,9 +14,9 @@
     "environment": [
       "EXTRA_OPTS=--graffiti=AVADO --beacon-rpc-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:4000 --beacon-rpc-gateway-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:3500"
     ],
-    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.26.tar.xz",
-    "hash": "/ipfs/QmeNdUWK82g1ZCg6yh8BY6MBuYH7vKzxowmtwpYzHxHQvK",
-    "size": 45714964,
+    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.27.tar.xz",
+    "hash": "/ipfs/QmYRd4iBbBqEgXnLn9gW6cGQeWGaDPATAr6KYdo8cdxdUU",
+    "size": 45737528,
     "restart": "always"
   },
   "author": "AVADO",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   eth2validator.avado.dnp.dappnode.eth:
-    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.26'
+    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.27'
     build:
       context: ./build
       args:
-        VERSION: v1.3.10
+        VERSION: v1.3.11
     environment:
       - >-
         EXTRA_OPTS=--graffiti="AVADO"

--- a/releases.json
+++ b/releases.json
@@ -179,5 +179,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Wed, 02 Jun 2021 18:52:46 GMT"
     }
+  },
+  "0.0.27": {
+    "hash": "/ipfs/QmNiEYNjpRLas4s3xxicrZGhv48U6tMp6mr8ArtwKKQor9",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Thu, 17 Jun 2021 12:13:35 GMT"
+    }
   }
 }


### PR DESCRIPTION
Prysm 1.3.11

Notable changes:
```
* Update web-ui: Fixes UI display issues
* Client stats graceful failure handling #8976
* Cache eviction policy for committees changed to LRU. 
Full list of changes: https://github.com/prysmaticlabs/prysm/releases/tag/v1.3.11
```
Manifest hash : /ipfs/QmNiEYNjpRLas4s3xxicrZGhv48U6tMp6mr8ArtwKKQor9
http://my.dappnode/#/installer/%2Fipfs%2FQmNiEYNjpRLas4s3xxicrZGhv48U6tMp6mr8ArtwKKQor9
