### PR TITLE
Update 0.0.28: Prysm v1.4.1

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth2validator.avado.dnp.dappnode.eth",
-  "version": "0.0.27",
-  "upstream": "v1.3.11",
+  "version": "0.0.28",
+  "upstream": "v1.4.1",
   "title": "Prysm ETH2.0 validator",
   "description": "the ETH2.0 validator for AVADO",
   "avatar": "/ipfs/Qmf7yFka8z2QLRrDyT1ESNRwP9a1tdufEEtBghXHFUEQEP",
@@ -14,9 +14,9 @@
     "environment": [
       "EXTRA_OPTS=--graffiti=AVADO --beacon-rpc-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:4000 --beacon-rpc-gateway-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:3500"
     ],
-    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.27.tar.xz",
-    "hash": "/ipfs/QmYRd4iBbBqEgXnLn9gW6cGQeWGaDPATAr6KYdo8cdxdUU",
-    "size": 45737528,
+    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.28.tar.xz",
+    "hash": "/ipfs/Qmd848imnsHNJoMNft4rKy7taoDTaRtsM2DFt799veWpfE",
+    "size": 45688080,
     "restart": "always"
   },
   "author": "AVADO",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth2validator.avado.dnp.dappnode.eth",
   "version": "0.0.28",
-  "upstream": "v1.4.1",
+  "upstream": "v1.4.2",
   "title": "Prysm ETH2.0 validator",
   "description": "the ETH2.0 validator for AVADO",
   "avatar": "/ipfs/Qmf7yFka8z2QLRrDyT1ESNRwP9a1tdufEEtBghXHFUEQEP",
@@ -15,8 +15,8 @@
       "EXTRA_OPTS=--graffiti=AVADO --beacon-rpc-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:4000 --beacon-rpc-gateway-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:3500"
     ],
     "path": "eth2validator.avado.dnp.dappnode.eth_0.0.28.tar.xz",
-    "hash": "/ipfs/Qmd848imnsHNJoMNft4rKy7taoDTaRtsM2DFt799veWpfE",
-    "size": 45688080,
+    "hash": "/ipfs/QmXmrSUa1W7CuTeMJeLv7tHU9XqjEAWMwCZWmqeMDistmn",
+    "size": 43750928,
     "restart": "always"
   },
   "author": "AVADO",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./build
       args:
-        VERSION: v1.4.1
+        VERSION: v1.4.2
     environment:
       - >-
         EXTRA_OPTS=--graffiti="AVADO"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   eth2validator.avado.dnp.dappnode.eth:
-    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.27'
+    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.28'
     build:
       context: ./build
       args:
-        VERSION: v1.3.11
+        VERSION: v1.4.1
     environment:
       - >-
         EXTRA_OPTS=--graffiti="AVADO"

--- a/releases.json
+++ b/releases.json
@@ -188,10 +188,10 @@
     }
   },
   "0.0.28": {
-    "hash": "/ipfs/QmYdT3D5BYt6bijiwddo2X6ZDNoSj3cUm4adjxoZgg7UNE",
+    "hash": "/ipfs/QmWwuH4La97Jgksgdz5QyzFGtaqi91No9j7jGGSxauY6z5",
     "type": "manifest",
     "uploadedTo": {
-      "http://80.208.229.228:5001": "Tue, 20 Jul 2021 19:44:24 GMT"
+      "http://80.208.229.228:5001": "Thu, 22 Jul 2021 16:02:04 GMT"
     }
   }
 }

--- a/releases.json
+++ b/releases.json
@@ -186,5 +186,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Thu, 17 Jun 2021 12:13:35 GMT"
     }
+  },
+  "0.0.28": {
+    "hash": "/ipfs/QmYdT3D5BYt6bijiwddo2X6ZDNoSj3cUm4adjxoZgg7UNE",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Tue, 20 Jul 2021 19:44:24 GMT"
+    }
   }
 }


### PR DESCRIPTION
https://github.com/prysmaticlabs/prysm/releases/tag/v1.4.1

update to support London hardfork

 Manifest hash : /ipfs/QmWwuH4La97Jgksgdz5QyzFGtaqi91No9j7jGGSxauY6z5
 http://my.dappnode/#/installer/%2Fipfs%2FQmWwuH4La97Jgksgdz5QyzFGtaqi91No9j7jGGSxauY6z5