### PR TITLE
Update 0.0.37: Prysm v2.0.5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,4 @@
+ARG VERSION
 
 # build image for monitor & wizard
 FROM node:14-alpine as builder-nodejs
@@ -13,7 +14,7 @@ RUN yarn build
 
 
 #TODO: DO NOT MERGE TO MASTER: use release $VERSION here instead
-FROM  gcr.io/prysmaticlabs/prysm/validator:latest as builder
+FROM  gcr.io/prysmaticlabs/prysm/validator:${VERSION} as builder
 
 FROM debian:buster-slim
 

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth2validator.avado.dnp.dappnode.eth",
-  "version": "0.0.36",
-  "upstream": "v2.0.2",
+  "version": "0.0.37",
+  "upstream": "v2.0.5",
   "title": "Prysm ETH2.0 validator",
   "description": "the ETH2.0 validator for AVADO",
   "avatar": "/ipfs/Qmf7yFka8z2QLRrDyT1ESNRwP9a1tdufEEtBghXHFUEQEP",
@@ -14,9 +14,9 @@
     "environment": [
       "EXTRA_OPTS=--graffiti=AVADO --beacon-rpc-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:4000 --beacon-rpc-gateway-provider=my.prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:3500"
     ],
-    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.36.tar.xz",
-    "hash": "/ipfs/Qmadw3swqtPDaKA7YCr6J6cFwn8BQtyYWCTHe1xLfKizYA",
-    "size": 44716856,
+    "path": "eth2validator.avado.dnp.dappnode.eth_0.0.37.tar.xz",
+    "hash": "/ipfs/QmZdp7fpRjtaZxhghmV7sWcBtSX676nStr69DsMZmRKgSf",
+    "size": 44260760,
     "restart": "always"
   },
   "author": "AVADO",
@@ -27,5 +27,5 @@
   "links": {
     "OnboardingWizard": "http://eth2validator.my.ava.do:81"
   },
-  "builddate": "2021-12-20T21:46:47.578Z"
+  "builddate": "2021-12-21T09:02:50.088Z"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   eth2validator.avado.dnp.dappnode.eth:
-    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.36'
+    image: 'eth2validator.avado.dnp.dappnode.eth:0.0.37'
     build:
       context: ./build
       args:
-        VERSION: v2.0.2
+        VERSION: v2.0.5
     environment:
       - >-
         EXTRA_OPTS=--graffiti="AVADO"

--- a/releases.json
+++ b/releases.json
@@ -249,5 +249,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Mon, 20 Dec 2021 21:46:48 GMT"
     }
+  },
+  "0.0.37": {
+    "hash": "/ipfs/QmW1hWHbQB63wFVW1hU1c3B2v2j8cn457EiEAkPQBWQ64x",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Tue, 21 Dec 2021 09:02:50 GMT"
+    }
   }
 }


### PR DESCRIPTION
https://github.com/prysmaticlabs/prysm/releases/tag/v2.0.5

Manifest hash: /ipfs/QmW1hWHbQB63wFVW1hU1c3B2v2j8cn457EiEAkPQBWQ64x